### PR TITLE
Tantares SP science defs compatibility

### DIFF
--- a/GameData/TantaresSP/TSP_sciencedefs_compatibility.cfg
+++ b/GameData/TantaresSP/TSP_sciencedefs_compatibility.cfg
@@ -1,0 +1,26 @@
+//Make ion trap use BDB science definition: any Science module within a part cfg gets their experiment ID switched if applicable
+@PART[TantaresSP*]:HAS:[@MODULE[ModuleScienceExperiment]:HAS[#experimentID[tantares_sp_ion_trap]]]:NEEDS[Bluedog_DB]
+{
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentID = logIonTrap
+    }
+}
+
+//Make cosmic ray detector use BDB Gamma Ray science definition: any Science module within a part cfg gets their experiment ID switched if applicable
+@PART[TantaresSP*]:HAS:[@MODULE[ModuleScienceExperiment]:HAS[#experimentID[tantares_sp_cosmic_ray_detector]]]:NEEDS[Bluedog_DB]
+{
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentID = bd_gammaRay
+    }
+}
+
+//Make cosmic ray detector use BDB Photometer science definition: any Science module within a part cfg gets their experiment ID switched if applicable
+@PART[TantaresSP*]:HAS:[@MODULE[ModuleScienceExperiment]:HAS[#experimentID[tantares_sp_visible_light_camera]]]:NEEDS[Bluedog_DB]
+{
+    @MODULE[ModuleScienceExperiment]
+    {
+        @experimentID = bd_Photometer
+    }
+}

--- a/GameData/TantaresSP/parts/any_sensor/1mv/_patch.cfg
+++ b/GameData/TantaresSP/parts/any_sensor/1mv/_patch.cfg
@@ -1,7 +1,0 @@
-@PART[1mv_sensor_ion_trap]:NEEDS[Bluedog_DB]
-{
-    @MODULE[ModuleScienceExperiment]
-    {
-        @experimentID = logIonTrap
-    }
-}

--- a/GameData/TantaresSP/parts/core_1mv/_patch.cfg
+++ b/GameData/TantaresSP/parts/core_1mv/_patch.cfg
@@ -8,14 +8,6 @@
 	}
 }
 
-@PART[1mv_sensor_visible_light_camera]:NEEDS[Bluedog_DB]
-{
-	@MODULE[ModuleScienceExperiment]
-	{
-		@experimentID = bd_camera
-	}
-}
-
 @PART[1mv_sensor_visible_light_camera_s0_1]:NEEDS[SCANsat]
 {
 	%MODULE


### PR DESCRIPTION
Moved existing ion trap and visible light compatibility patches out of specific parts folders and into 1 compatibility patch file - easier for future patching and reference. This also facilitates change #2: blanket patching of any experiment with the affected definitions, instead of per-part patches. This makes adding future parts with these definitions more hassle-free.
Added patches for Cosmic-ray -> bd_gammaray and changed visible light patch to bd_photometer (was bd_camera, photometer however is more authentic with regard to the real usage and the part name).

Didn't touch magnetometer due it being stock definition. Dmagic's is arguably better, but that is up to creator's discretion to decide :)